### PR TITLE
Add data-coupon attribute to input in README.md

### DIFF
--- a/packages/shopaholic-coupon/README.md
+++ b/packages/shopaholic-coupon/README.md
@@ -14,7 +14,7 @@ npm install @lovata/shopaholic-coupon
 ## Basic usage
 
 ```html
-<input type="text" name="coupon" value="">
+<input type="text" name="coupon" data-coupon="" value="">
 
 <button class="_shopaholic-coupon-add">Apply coupon</button>
 <button class="_shopaholic-coupon-remove">Remove coupon</button>


### PR DESCRIPTION
In the code, you are selecting input by the data-coupon attribute, but the example does not https://github.com/oc-shopaholic/oc-shopaholic-js-helpers/blob/7d5ebb233a9b19cb9159ff436f98937484f1c135/packages/shopaholic-coupon/shopaholic-coupon-add.js#L24